### PR TITLE
vim terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ terminal multiplexer, for communicating with between Vim and the Tidal
 interpreter.  It was originally based on
 [vim-slime](https://github.com/jpalardy/vim-slime).
 
-**New**: If you are using NeoVim, you can now use the Terminal instead of tmux.
-Read the Configuration section on how to enable it.
+**New**: You can now use the Terminal instead of tmux.  Read the Configuration
+section on how to enable it.
 
 ![](http://i.imgur.com/frOLFFI.gif)
 
@@ -245,10 +245,10 @@ on the window 1 and pane 0.  In that case you would need to add this line:
 let g:tidal_default_config = {"socket_name": "default", "target_pane": "omg:1.0"}
 ```
 
-### NeoVim Terminal target ###
+### Terminal target ###
 
-If you are using NeoVim, you can ditch tmux and use the terminal. Add the
-following line on your configuration file:
+You can now ditch tmux and use the terminal.  Add the following line on your
+configuration file:
 
 ```vim
 let g:tidal_target = "terminal"

--- a/bin/tidal
+++ b/bin/tidal
@@ -8,7 +8,7 @@ function setdir {
 
   # Resolve $SOURCE until the file is no longer a symlink
   while [ -h "$source" ]; do
-    dir="$( cd -P "$( dirname "$source" )" && pwd )"
+    DIR="$( cd -P "$( dirname "$source" )" && pwd )"
     source="$(readlink "$source")"
 
     # If $SOURCE was a relative symlink, we need to resolve it relative to the

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -44,18 +44,17 @@ endfunction
 let s:tidal_term = -1
 
 function! s:TerminalOpen()
-  if !has('nvim')
-    echom "'terminal' target currently supported on NeoVim only. Use 'tmux'"
-    return
-  endif
-
   if s:tidal_term != -1
     return
   endif
 
-  split term://tidal
-
-  let s:tidal_term = b:terminal_job_id
+  if has('nvim')
+    split term://tidal
+    let s:tidal_term = b:terminal_job_id
+  else
+    term tidal
+    let s:tidal_term = 2
+  endif
 
   " Give tidal a moment to start up so the command doesn't show up at the top
   " unaesthetically.
@@ -74,7 +73,11 @@ endfunction
 
 function! s:TerminalSend(config, text)
   call s:TerminalOpen()
-  call jobsend(s:tidal_term, a:text)
+  if has('nvim')
+    call jobsend(s:tidal_term, a:text)
+  else
+    call term_sendkeys(s:tidal_term, a:text)
+  end
 endfunction
 
 " These two are unnecessary AFAIK.


### PR DESCRIPTION
Add support for terminal in plain vim, too.

Also, fix a TYPO in `bin/tidal` that stops the symlink walk from working.