### PR TITLE
Update to Tidal 1.6.1

### DIFF
--- a/Tidal.ghci
+++ b/Tidal.ghci
@@ -5,14 +5,21 @@ import Sound.Tidal.Context
 
 import System.IO (hSetEncoding, stdout, utf8)
 
+import qualified Control.Concurrent.MVar as MV
+import qualified Sound.Tidal.Tempo as Tempo
+
 hSetEncoding stdout utf8
 
 -- total latency = oLatency + cFrameTimespan
 tidal <- startTidal (superdirtTarget {oLatency = 0.1, oAddress = "127.0.0.1", oPort = 57120}) (defaultConfig {cFrameTimespan = 1/20})
 
 :{
-let p = streamReplace tidal
+let only = (hush >>)
+    p = streamReplace tidal
     hush = streamHush tidal
+    panic = do
+        hush
+        once $ sound "superpanic"
     list = streamList tidal
     mute = streamMute tidal
     unmute = streamUnmute tidal
@@ -25,6 +32,9 @@ let p = streamReplace tidal
     all = streamAll tidal
     resetCycles = streamResetCycles tidal
     setcps = asap . cps
+    getcps = do
+        tempo <- MV.readMVar $ sTempoMV tidal
+        return $ Tempo.cps tempo
     xfade i = transition tidal True (Sound.Tidal.Transition.xfadeIn 4) i
     xfadeIn i t = transition tidal True (Sound.Tidal.Transition.xfadeIn t) i
     histpan i t = transition tidal True (Sound.Tidal.Transition.histpan t) i


### PR DESCRIPTION
Includes what is needed in order to `getcps` to work properly, plus `only` and `panic`.