### PR TITLE
Change bin paths for NixOS compatibility

### DIFF
--- a/bin/generate-completions
+++ b/bin/generate-completions
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 samplepath=$1
 outputpath=$2

--- a/bin/tidal
+++ b/bin/tidal
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euf -o pipefail
 
 # Get current directory (of script)

--- a/bin/tidalvim
+++ b/bin/tidalvim
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euf -o pipefail
 
 VIM=${VIM:-"vim"}


### PR DESCRIPTION
On NixOS, shells like `sh` and `bash` aren't found in `/bin`; rather, they're stored elsewhere and found in the system environment. Because of this, `#!/bin/bash` will fail to find the bash shell on NixOS systems.

On the contrary, `#!/usr/bin/env sh` is compatible with all Linux systems.