### PR TITLE
Changed window rearrangement commands to respect existing splits

### DIFF
--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -66,8 +66,7 @@ function! s:TerminalOpen()
   :exe "normal G"
 
   " Make small & on the bottom.
-  :exe "normal \<c-w>J"
-  :exe "normal \<c-w>\<c-w>"
+  :exe "normal \<c-w>x"
   :exe "normal \<c-w>_"
   :exe "normal \<c-w>10-"
 endfunction


### PR DESCRIPTION
The previous window rearrangement code in the `s:TerminalOpen()` function would terminal window all the way to the bottom of the screen, regardless of existing splits. This small change simply rotates it below the `.tidal` file window, and makes it 10 lines tall.