### PR TITLE
run `tidal` script from <PLUGIN DIR>/bin instead of $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Plug 'tidalcycles/vim-tidal'
 
 If you are on a UNIX-based operating system (Linux distributions, MacOS, etc.), go to the plugin repository and run `make install`:
 
+(if you are using NeoVim and you won't run tmux then you don't need to run `make install` to be able to load the plugin inside NeoVim)
+
     $ cd ~/.vim/plugged/vim-tidal
     $ sudo make install
 

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -53,7 +53,7 @@ function! s:TerminalOpen()
     return
   endif
 
-  split term://tidal
+  split term://../bin/tidal
 
   let s:tidal_term = b:terminal_job_id
 


### PR DESCRIPTION
it simplifies setup when using Nvim without tmux, that way it is not mandatory
to run `make install` to use the plugin