### PR TITLE
load BootTidal.hs from tidal Hackage on *nix systems

### DIFF
--- a/bin/tidal
+++ b/bin/tidal
@@ -1,27 +1,9 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
 
-# Get current directory (of script)
-# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
-function setdir {
-  local source="${BASH_SOURCE[0]}"
-
-  # Resolve $SOURCE until the file is no longer a symlink
-  while [ -h "$source" ]; do
-    dir="$( cd -P "$( dirname "$source" )" && pwd )"
-    source="$(readlink "$source")"
-
-    # If $SOURCE was a relative symlink, we need to resolve it relative to the
-    # path where the symlink file was located
-    [[ $source != /* ]] && source="$DIR/$source"
-  done
-  DIR="$( cd -P "$( dirname "$source" )" && pwd )"
-}
-
-setdir
-
-TIDAL_BOOT_PATH=${TIDAL_BOOT_PATH:-"$DIR/../Tidal.ghci"}
 GHCI=${GHCI:-"ghci"}
+TIDAL_DATA_DIR=$($GHCI -e Paths_tidal.getDataDir | sed 's/"//g')
+TIDAL_BOOT_PATH=${TIDAL_BOOT_PATH:-"$TIDAL_DATA_DIR/BootTidal.hs"}
 
 # Run GHCI and load Tidal bootstrap file
 $GHCI -ghci-script $TIDAL_BOOT_PATH "$@"


### PR DESCRIPTION
the Tidal.ghci has exactly the same code as BootTidal.hs from tidal Haskell
package, that code duplication could be avoided by loading the boot file straight
from tidal Haskell package

for now we can't remove Tidal.ghci cause tidal.bat on Windows still needs that
file, but on *nix environments the BootTidal.hs is being used instead Tidal.ghci

if possible would be great to develop the same solution of this commit also on
tidal.bat script then the Tidal.ghci can be removed from vim-tidal