### PR TITLE
Allow for customising the Tidal GHCI boot file with `g:tidal_boot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,22 @@ For example, if one installed Tidal with Stack, they would use:
 let g:tidal_ghci = "stack exec ghci --"
 ```
 
+### Tidal Boot File
+
+A "Tidal boot file" is a file that may be used to initialise Tidal within GHCI.
+A custom boot file can be specified using the `g:tidal_boot` variable.
+
+In the case that `g:tidal_boot` is unspecified, vim-tidal will traverse parent
+directories until one of either `BootTidal.hs`, `Tidal.ghci` or `boot.tidal` are
+found.
+
+If no tidal boot file can be found by traversing parent directories, tidal will
+check the `g:tidal_boot_fallback` variable for a fallback boot file. This
+variable is useful for specifying a default user-wide tidal boot file on your
+system, while still allowing each tidal project to optionally use their own
+dedicated, local tidal boot file. By default, `g:tidal_boot_fallback` will point
+to the `Tidal.ghci` file provided with this plugin.
+
 ### Default bindings ###
 
 By default, there are two normal keybindings and one for visual blocks using

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -36,6 +36,10 @@ if !exists("g:tidal_ghci")
   let g:tidal_ghci = "ghci"
 endif
 
+if !exists("g:tidal_boot")
+  let g:tidal_boot = s:parent_path . "/Tidal.ghci"
+endif
+
 if filereadable(s:parent_path . "/.dirt-samples")
   let &l:dictionary .= ',' . s:parent_path . "/.dirt-samples"
 endif
@@ -105,9 +109,8 @@ function! s:TerminalOpen()
     :exe "normal \<c-w>10-"
 
   elseif has('terminal')
-    let startup = s:parent_path . "/Tidal.ghci"
     execute "below split"
-    let s:tidal_term = term_start((g:tidal_ghci . " -ghci-script=" . startup), #{
+    let s:tidal_term = term_start((g:tidal_ghci . " -ghci-script=" . g:tidal_boot), #{
           \ term_name: 'tidal',
           \ term_rows: 10,
           \ norestore: 1,

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -46,9 +46,13 @@ if !exists("g:tidal_ghci")
   let g:tidal_ghci = "ghci"
 endif
 
+if !exists("g:tidal_boot_fallback")
+  let g:tidal_boot_fallback = s:parent_path . "/Tidal.ghci"
+endif
+
 if !exists("g:tidal_boot")
   let g:tidal_boot = s:FindTidalBoot()
-  if empty(g:tidal_boot) && exists("g:tidal_boot_fallback")
+  if empty(g:tidal_boot)
     let g:tidal_boot = g:tidal_boot_fallback
   endif
 endif

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -8,6 +8,16 @@ let s:parent_path = fnamemodify(expand("<sfile>"), ":p:h:s?/plugin??")
 " Default config
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
+" Attempts to find a tidal boot file in this or any parent directory.
+function s:FindTidalBoot()
+  for name in ["BootTidal.hs", "Tidal.ghci", "boot.tidal"]
+    let tidal_boot_file = findfile(name, ".".';')
+    if !empty(tidal_boot_file)
+      return tidal_boot_file
+    endif
+  endfor
+endfunction
+
 if !exists("g:tidal_target")
   if has('nvim') || has('terminal')
     let g:tidal_target = "terminal"
@@ -37,7 +47,10 @@ if !exists("g:tidal_ghci")
 endif
 
 if !exists("g:tidal_boot")
-  let g:tidal_boot = s:parent_path . "/Tidal.ghci"
+  let g:tidal_boot = s:FindTidalBoot()
+  if empty(g:tidal_boot) && exists("g:tidal_boot_fallback")
+    let g:tidal_boot = g:tidal_boot_fallback
+  endif
 endif
 
 if filereadable(s:parent_path . "/.dirt-samples")


### PR DESCRIPTION
This allows a user to specify the target Tidal GHCI boot file via the `g:tidal_boot` or `g:tidal_boot_fallback` variables. Please see the new "Tidal Boot File" subsection under the "Configure" section within the README for details on the new behaviour.

In the case that a user does not specify either of these variables and does not use any custom, local boot file within their projects, the default behaviour remains unchanged and the `Tidal.ghci` file provided with this plugin will be used.

This is originally motivated by [tidalcycles.nix][1], as the new variables can be used to specify the `BootTidal.hs` file provided by the tidal library itself within the `/nix/store` as the default tidal boot file, rather than using the one provided by `vim-tidal` which can often lag behind.

[1]: https://github.com/mitchmindtree/tidalcycles.nix