### PR TITLE
Fix tmux newline bug introduced in Vim Terminal support PR

### DIFF
--- a/ftplugin/tidal.vim
+++ b/ftplugin/tidal.vim
@@ -31,7 +31,13 @@ endfunction
 
 " change lines back into text
 function! Unlines(lines)
-    return join(a:lines, "\n")
+    if g:tidal_target == "tmux"
+        " Without this, the user has to manually submit a newline each time
+        " they evaluate an expression with `ctrl e`.
+        return join(a:lines, "\n") . "\n"
+    else
+        return join(a:lines, "\n")
+    endif
 endfunction
 
 " vim slime handler


### PR DESCRIPTION
Bug introduced in 1f4d11548c9f25d12ce56015b31b60b264ff226a.

This bug previously caused users of the tmux target to need to enter an extra newline every time they sent an expression to ghci with `ctrl e`.

This fixes the behaviour by checking the `g:tidal_target` before determining whether we need to send a newline.

Closes #80

cc @lazakoa