### PR TITLE
Add start/stop/restart commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ These are some of the commands that can be run from Vim command line:
 * `:TidalGenerateCompletions {path}`: Generate dictionary for Dirt-Samples
   completion (path is optional).
 
+* `:TidalStart`: Start GHCi/SuperCollider without running any commands
+
+* `:TidalStop`: Stop GHCi/SuperCollider immediately
+
+* `:TidalRestart`: Restart GHCi/SuperCollider
+
 ### Default bindings
 
 Using one of these key bindings you can send lines to Tidal:

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -412,9 +412,35 @@ function! s:TidalGenerateCompletions(path)
   let &l:dictionary .= ',' . l:output_path
 endfunction
 
+function! s:TidalStart()
+  call s:TerminalOpen()
+endfunction
+
+function! s:TidalStop()
+  " TODO check if nvim and tmux work this way too
+  if s:tidal_term_ghci != -1
+    execute "bwipeout! " . s:tidal_term_ghci
+    let s:tidal_term_ghci = -1
+
+    if g:tidal_sc_enable == 1 && s:tidal_term_sc != -1
+      execute "bwipeout! " . s:tidal_term_sc
+      let s:tidal_term_sc = -1
+    endif
+  endif
+endfunction
+
+function! s:TidalRestart()
+  call s:TidalStop()
+  call s:TidalStart()
+endfunction
+
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Setup key bindings
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+command! -nargs=0 TidalStart call s:TidalStart()
+command! -nargs=0 TidalStop call s:TidalStop()
+command! -nargs=0 TidalRestart call s:TidalRestart()
 
 command -bar -nargs=0 TidalConfig call s:TidalConfig()
 command -range -bar -nargs=0 TidalSend <line1>,<line2>call s:TidalSendRange()


### PR DESCRIPTION
Hello! It is quite useful to have explicit commands to start/stop/restart the Tidal process, so I added them in this PR as `:Tidal{Start,Stop,Restart}`. I only use regular old Vim 9 so I can't speak to their correctness on Neovim or in Tmux. Please advise on any style issues or Vimscript esoterica - this is my first time writing it!