### PR TITLE
add :TidalPanic command like :TidalHush

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ These are some of the commands that can be run from Vim command line:
 
 * `:TidalHush`: Silences all streams by sending `hush`.
 
+* `:TidalPanic`: Silences Tidal immediately by sending `panic`.
+
 * `:TidalGenerateCompletions {path}`: Generate dictionary for Dirt-Samples
   completion (path is optional).
 

--- a/ftplugin/tidal.vim
+++ b/ftplugin/tidal.vim
@@ -74,6 +74,8 @@ if !exists("g:tidal_no_mappings") || !g:tidal_no_mappings
 
   nnoremap <buffer> <localleader>h :TidalHush<cr>
   nnoremap <buffer> <c-h> :TidalHush<cr>
+  nnoremap <buffer> <localleader>p :TidalPanic<cr>
+  nnoremap <buffer> <c-p> :TidalPanic<cr>
   let i = 1
   while i <= 9
     execute 'nnoremap <buffer> <localleader>'.i.'  :TidalSilence '.i.'<cr>'

--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -377,6 +377,10 @@ function! s:TidalHush()
   execute 'TidalSend1 hush'
 endfunction
 
+function! s:TidalPanic()
+  execute 'TidalSend1 panic'
+endfunction
+
 function! s:TidalSilence(stream)
   silent execute 'TidalSend1 d' . a:stream . ' silence'
 endfunction
@@ -421,6 +425,7 @@ command -range -bar -nargs=0 TidalSend <line1>,<line2>call s:TidalSendRange()
 command -nargs=+ TidalSend1 call s:TidalSend(<q-args>)
 
 command! -nargs=0 TidalHush call s:TidalHush()
+command! -nargs=0 TidalPanic call s:TidalPanic()
 command! -nargs=1 TidalSilence call s:TidalSilence(<args>)
 command! -nargs=1 TidalPlay call s:TidalPlay(<args>)
 command! -nargs=? TidalGenerateCompletions call s:TidalGenerateCompletions(<q-args>)


### PR DESCRIPTION
This just copies the code for `:TidalHush` to add another command that sends `panic`, which is useful when you've triggered a long sample or caused some other cacophony. I've bound it to `<leader>p` or `<c-p>` by default - a different keybinding may be better.