### PR TITLE
Fix how the parent path is computed

### DIFF
--- a/plugin/tidal.vim
+++ b/plugin/tidal.vim
@@ -2,7 +2,7 @@ if exists("g:loaded_tidal") || &cp || v:version < 700
   finish
 endif
 let g:loaded_tidal = 1
-let s:parent_path = fnamemodify(expand("<sfile>"), ":p:h:s?/plugin??")
+let s:parent_path = expand("<sfile>:p:h:h")
 
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Default config


### PR DESCRIPTION
Currently, the path is computed by string replacement. However, if `plugin` appear in the path, this will result in an invalid path as the plugin string will be replaced. Instead, we can use `:h` on the path to get the parent directory.
